### PR TITLE
Prevent warning when calling setStatus on a HEAD request

### DIFF
--- a/flak-backend-jdk/src/main/java/flak/backend/jdk/JdkRequest.java
+++ b/flak-backend-jdk/src/main/java/flak/backend/jdk/JdkRequest.java
@@ -157,7 +157,8 @@ public class JdkRequest implements SPRequest, Response {
 
   public void setStatus(int status) {
     try {
-      exchange.sendResponseHeaders(status, 0);
+      long l = "HEAD".equals(exchange.getRequestMethod()) ? -1 : 0;
+      exchange.sendResponseHeaders(status, l);
     }
     catch (IOException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
It fixes the warnings generated when we call `Response#setStatus` on a `HEAD` request

```
Oct 02, 2019 12:32:34 PM sun.net.httpserver.ExchangeImpl sendResponseHeaders
WARNING: sendResponseHeaders: being invoked with a content length for a HEAD request
Oct 02, 2019 12:32:34 PM sun.net.httpserver.ExchangeImpl sendResponseHeaders
WARNING: sendResponseHeaders: being invoked with a content length for a HEAD request
```