### PR TITLE
Support compression (gzip content encoding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Flak components    | Description
          * [Query argument](#query-argument)
          * [Form argument](#form-argument)
          * [Custom arguments](#custom-arguments)
+      * [Compression](#compression)
       * [Managing apps](#managing-apps)
       * [To be continued....](#to-be-continued)
    * [Why Flak?](#why-flak)
@@ -39,7 +40,7 @@ Flak components    | Description
       * [How to publish locally](#how-to-publish-locally)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-<!-- Added by: pcdv, at: Sat Sep 10 06:05:40     2022 -->
+<!-- Added by: pcdv, at: Sun Dec 31 19:04:56     2023 -->
 
 <!--te-->
 <!-- to update TOC:
@@ -208,6 +209,17 @@ You can accept other argument types if you:
   }
 ```
  
+### Compression
+
+Gzip compression can be enabled for a given endpoint or all endpoints of a 
+class by using the `@Compress` annotation.
+
+Files served with `FlakResourceImpl` will be automatically compressed 
+according to their content type and size.
+
+It is possible to tune compression behavior:
+ * file size threshold (using system property `flak.compressThreshold`)
+ * eligible content types (using a custom `ContentTypeProvider`)
 
 ### Managing apps
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ You can accept other argument types if you:
 ### Compression
 
 Gzip compression can be enabled for a given endpoint or all endpoints of a 
-class by using the `@Compress` annotation.
+class by using the `@Compress` annotation. Alternatively, it can be enabled
+using method `Response.setCompressionAllowed(true)`.
 
 Files served with `FlakResourceImpl` will be automatically compressed 
 according to their content type and size.

--- a/flak-api/src/main/java/flak/Response.java
+++ b/flak-api/src/main/java/flak/Response.java
@@ -12,6 +12,11 @@ public interface Response {
   void addHeader(String header, String value);
 
   /**
+   * Checks whether specified response header is set.
+   */
+  boolean hasResponseHeader(String name);
+
+  /**
    * Warning: must be called after addHeader().
    *
    * @see java.net.HttpURLConnection
@@ -27,4 +32,16 @@ public interface Response {
    * location.
    */
   void redirect(String path);
+
+  /**
+   * Configures whether gzip compression can be applied automatically according
+   * to Accept-Encoding request header and absence of Content-Encoding response
+   * header (false by default).
+   */
+  void setCompressionAllowed(boolean compressionAllowed);
+
+  /**
+   * @see #setCompressionAllowed(boolean)
+   */
+  boolean isCompressionAllowed();
 }

--- a/flak-api/src/main/java/flak/annotations/Compress.java
+++ b/flak-api/src/main/java/flak/annotations/Compress.java
@@ -1,0 +1,15 @@
+package flak.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Enables compression on an endpoint, or all endpoints of a class.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Compress {
+  int COMPRESS_THRESHOLD = Integer.getInteger("flak.compressThreshold", 1024);
+}

--- a/flak-api/src/main/java/flak/annotations/Compress.java
+++ b/flak-api/src/main/java/flak/annotations/Compress.java
@@ -11,5 +11,4 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Compress {
-  int COMPRESS_THRESHOLD = Integer.getInteger("flak.compressThreshold", 1024);
 }

--- a/flak-backend-jdk/src/main/java/flak/backend/jdk/HeaderList.java
+++ b/flak-backend-jdk/src/main/java/flak/backend/jdk/HeaderList.java
@@ -16,4 +16,8 @@ class HeaderList {
       exchange.getResponseHeaders().add(arr[0], arr[1]);
     }
   }
+
+  public boolean has(String name) {
+    return list.stream().anyMatch(arr -> name.equals(arr[0]));
+  }
 }

--- a/flak-backend-jdk/src/main/java/flak/backend/jdk/MethodHandler.java
+++ b/flak-backend-jdk/src/main/java/flak/backend/jdk/MethodHandler.java
@@ -1,7 +1,6 @@
 package flak.backend.jdk;
 
 import flak.Response;
-import flak.annotations.Compress;
 import flak.spi.AbstractMethodHandler;
 import flak.spi.CompressionHelper;
 import flak.spi.SPRequest;
@@ -72,13 +71,13 @@ public class MethodHandler extends AbstractMethodHandler {
       OutputStream out = r.getOutputStream();
       if (res instanceof String) {
         r.setStatus(HttpURLConnection.HTTP_OK);
-        if (((String) res).length() > Compress.COMPRESS_THRESHOLD)
+        if (((String) res).length() > CompressionHelper.COMPRESS_THRESHOLD)
           out = CompressionHelper.maybeCompress(r);
         out.write(((String) res).getBytes(StandardCharsets.UTF_8));
       }
       else if (res instanceof byte[]) {
         r.setStatus(HttpURLConnection.HTTP_OK);
-        if (((byte[]) res).length > Compress.COMPRESS_THRESHOLD)
+        if (((byte[]) res).length > CompressionHelper.COMPRESS_THRESHOLD)
           out = CompressionHelper.maybeCompress(r);
         out.write((byte[]) res);
       }

--- a/flak-backend-netty/src/main/java/flak/backend/netty/NettyResponse.java
+++ b/flak-backend-netty/src/main/java/flak/backend/netty/NettyResponse.java
@@ -1,7 +1,7 @@
 package flak.backend.netty;
 
 import flak.Request;
-import flak.Response;
+import flak.spi.SPResponse;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
@@ -13,7 +13,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 
-public class NettyResponse implements Response {
+public class NettyResponse implements SPResponse {
   private final NettyRequest req;
   private final DefaultHttpHeaders headers;
   private int status = 200;
@@ -31,6 +31,11 @@ public class NettyResponse implements Response {
   @Override
   public void addHeader(String header, String value) {
     headers.add(header, value);
+  }
+
+  @Override
+  public boolean hasResponseHeader(String name) {
+    return headers.contains(name);
   }
 
   @Override
@@ -54,6 +59,16 @@ public class NettyResponse implements Response {
     setStatus(HttpURLConnection.HTTP_MOVED_TEMP);
   }
 
+  @Override
+  public void setCompressionAllowed(boolean compressionAllowed) {
+
+  }
+
+  @Override
+  public boolean isCompressionAllowed() {
+    return false;
+  }
+
   public int getStatus() {
     return status;
   }
@@ -66,5 +81,10 @@ public class NettyResponse implements Response {
     //r.headers().set(HttpHeaderNames.CONTENT_LENGTH, 0);
     //HttpUtil.setKeepAlive(r, false);
     //return r;
+  }
+
+  @Override
+  public void setOutputStream(OutputStream out) {
+    throw new RuntimeException("TODO");
   }
 }

--- a/flak-jackson/src/main/java/flak/jackson/JsonOutputFormatter.java
+++ b/flak-jackson/src/main/java/flak/jackson/JsonOutputFormatter.java
@@ -3,6 +3,7 @@ package flak.jackson;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import flak.OutputFormatter;
 import flak.Response;
+import flak.spi.CompressionHelper;
 
 /**
  * An output formatter using an ObjectWriter, which is the recommended way of
@@ -25,7 +26,6 @@ public class JsonOutputFormatter<T> implements OutputFormatter<T> {
   @Override
   public void convert(T data, Response resp) throws Exception {
     resp.addHeader("Content-Type", "application/json");
-    resp.setStatus(200);
-    writer.writeValue(resp.getOutputStream(), data);
+    writer.writeValue(CompressionHelper.maybeCompress(resp), data);
   }
 }

--- a/flak-resource/src/main/java/flak/plugin/resource/ContentTypeProvider.java
+++ b/flak-resource/src/main/java/flak/plugin/resource/ContentTypeProvider.java
@@ -13,4 +13,11 @@ public interface ContentTypeProvider {
    */
   String getContentType(String path);
 
+  /**
+   * Used when serving resources, to help determine if a document should be
+   * compressed.
+   */
+  default boolean shouldCompress(String contentType) {
+    return contentType.contains("text") || contentType.contains("/json");
+  }
 }

--- a/flak-resource/src/main/java/flak/plugin/resource/FileHandler.java
+++ b/flak-resource/src/main/java/flak/plugin/resource/FileHandler.java
@@ -1,6 +1,6 @@
 package flak.plugin.resource;
 
-import flak.annotations.Compress;
+import flak.spi.CompressionHelper;
 import flak.spi.SPResponse;
 
 import java.io.File;
@@ -26,7 +26,7 @@ public class FileHandler extends AbstractResourceHandler {
     if (p.startsWith("/"))
       p = p.substring(1);
     File file = localPath.resolve(p).toFile();
-    if (file.length() > Compress.COMPRESS_THRESHOLD)
+    if (file.length() > CompressionHelper.COMPRESS_THRESHOLD)
       resp.setCompressionAllowed(true);
     return Files.newInputStream(file.toPath());
   }

--- a/flak-resource/src/main/java/flak/plugin/resource/FileHandler.java
+++ b/flak-resource/src/main/java/flak/plugin/resource/FileHandler.java
@@ -1,9 +1,12 @@
 package flak.plugin.resource;
 
+import flak.annotations.Compress;
+import flak.spi.SPResponse;
+
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class FileHandler extends AbstractResourceHandler {
@@ -19,9 +22,12 @@ public class FileHandler extends AbstractResourceHandler {
   }
 
   @Override
-  protected InputStream openPath(String p) throws FileNotFoundException {
+  protected InputStream openPath(String p, SPResponse resp) throws IOException {
     if (p.startsWith("/"))
       p = p.substring(1);
-    return new FileInputStream(localPath.resolve(p).toFile());
+    File file = localPath.resolve(p).toFile();
+    if (file.length() > Compress.COMPRESS_THRESHOLD)
+      resp.setCompressionAllowed(true);
+    return Files.newInputStream(file.toPath());
   }
 }

--- a/flak-resource/src/main/java/flak/plugin/resource/ResourceHandler.java
+++ b/flak-resource/src/main/java/flak/plugin/resource/ResourceHandler.java
@@ -3,6 +3,7 @@ package flak.plugin.resource;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 
+import flak.spi.SPResponse;
 import flak.spi.util.Log;
 
 /**
@@ -29,7 +30,7 @@ public class ResourceHandler extends AbstractResourceHandler {
   }
 
   @Override
-  protected InputStream openPath(String p) throws FileNotFoundException {
+  protected InputStream openPath(String p, SPResponse resp) throws FileNotFoundException {
     p = localPath + p;
 
     if (!p.startsWith("/"))
@@ -52,6 +53,9 @@ public class ResourceHandler extends AbstractResourceHandler {
 
     if (in == null)
       throw new FileNotFoundException(p);
+
+    // no way of knowing the size of resource, so we always allow compression
+    resp.setCompressionAllowed(true);
 
     return in;
   }

--- a/flak-spi/src/main/java/flak/spi/AbstractMethodHandler.java
+++ b/flak-spi/src/main/java/flak/spi/AbstractMethodHandler.java
@@ -6,6 +6,7 @@ import flak.OutputFormatter;
 import flak.Query;
 import flak.Request;
 import flak.Response;
+import flak.annotations.Compress;
 import flak.annotations.Delete;
 import flak.annotations.Head;
 import flak.annotations.InputFormat;
@@ -64,6 +65,7 @@ public abstract class AbstractMethodHandler
    * The object to invoke method on (i.e. the actual handler).
    */
   protected final Object target;
+  protected final boolean allowCompress;
 
   @SuppressWarnings("rawtypes")
   protected OutputFormatter outputFormat;
@@ -97,6 +99,8 @@ public abstract class AbstractMethodHandler
     this.splitPath = splitPath;
     this.httpMethod = getHttpMethod(m);
     this.outputFormat = getOutputFormat(m);
+    this.allowCompress = m.getAnnotation(Compress.class) != null
+      || m.getDeclaringClass().getAnnotation(Compress.class) != null;
     this.javaMethod = m;
     this.target = target;
 
@@ -104,7 +108,6 @@ public abstract class AbstractMethodHandler
     // is not public
     if (!m.isAccessible())
       m.setAccessible(true);
-
   }
 
   public void init() {

--- a/flak-spi/src/main/java/flak/spi/CompressionHelper.java
+++ b/flak-spi/src/main/java/flak/spi/CompressionHelper.java
@@ -11,6 +11,8 @@ import java.util.zip.GZIPOutputStream;
  */
 public class CompressionHelper {
 
+  public static final int COMPRESS_THRESHOLD = Integer.getInteger("flak.compressThreshold", 1024);
+
   /**
    * Attempts to compress the response output stream if compression is allowed,
    * the client supports gzip encoding, and content encoding is not already set.

--- a/flak-spi/src/main/java/flak/spi/CompressionHelper.java
+++ b/flak-spi/src/main/java/flak/spi/CompressionHelper.java
@@ -1,0 +1,33 @@
+package flak.spi;
+
+import flak.Response;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Utility class for handling compression of HTTP response data.
+ */
+public class CompressionHelper {
+
+  /**
+   * Attempts to compress the response output stream if compression is allowed,
+   * the client supports gzip encoding, and content encoding is not already set.
+   * If compression is applied, sets the Content-Encoding header to "gzip".
+   *
+   * @param resp The HTTP response to be compressed.
+   * @return The output stream of the response (compressed if applicable).
+   * @throws IOException If an I/O error occurs during compression setup.
+   */
+  public static OutputStream maybeCompress(Response resp) throws IOException {
+    String acceptEncoding = resp.getRequest().getHeader("Accept-Encoding");
+    if (resp.isCompressionAllowed()
+      && acceptEncoding != null && acceptEncoding.contains("gzip")
+      && !resp.hasResponseHeader("Content-Encoding")) {
+      resp.addHeader("Content-Encoding", "gzip");
+      ((SPResponse) resp).setOutputStream(new GZIPOutputStream(resp.getOutputStream()));
+    }
+    return resp.getOutputStream();
+  }
+}

--- a/flak-spi/src/main/java/flak/spi/SPResponse.java
+++ b/flak-spi/src/main/java/flak/spi/SPResponse.java
@@ -1,0 +1,15 @@
+package flak.spi;
+
+import flak.Response;
+
+import java.io.OutputStream;
+
+public interface SPResponse extends Response {
+
+  /**
+   * Used when applying compression, to wrap the default output stream in a
+   * {@link java.util.zip.GZIPOutputStream}.
+   */
+  void setOutputStream(OutputStream out);
+
+}

--- a/flak-tests/src/test/java/flask/test/AbstractAppTest.java
+++ b/flak-tests/src/test/java/flask/test/AbstractAppTest.java
@@ -52,6 +52,7 @@ public class AbstractAppTest {
     else {
       client = new SimpleClient(app.getRootUrl());
     }
+    client.addHeader("Accept-Encoding", "gzip");
   }
 
   protected void initFlakLogin() {

--- a/flak-tests/src/test/java/flask/test/BigOutputTest.java
+++ b/flak-tests/src/test/java/flask/test/BigOutputTest.java
@@ -1,6 +1,7 @@
 package flask.test;
 
 import flak.Response;
+import flak.annotations.Compress;
 import flak.annotations.Route;
 import org.junit.Assert;
 import org.junit.Test;
@@ -12,6 +13,7 @@ import java.util.Arrays;
  * Reproduce inconsistencies when buffer is flushed before headers and status
  * are set.
  */
+@Compress
 public class BigOutputTest extends AbstractAppTest {
 
   @Route("/api/data")
@@ -29,6 +31,8 @@ public class BigOutputTest extends AbstractAppTest {
   @Test
   public void test() throws Exception {
     Assert.assertEquals(getBigString(), client.get("/api/data"));
+    Assert.assertEquals("gzip", client.getLastConnection().getContentEncoding());
     Assert.assertEquals(getBigString(), client.get("/api/data2"));
+    Assert.assertNull(client.getLastConnection().getContentEncoding());
   }
 }

--- a/flak-tests/src/test/java/flask/test/util/SimpleClient.java
+++ b/flak-tests/src/test/java/flask/test/util/SimpleClient.java
@@ -11,6 +11,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -31,7 +32,8 @@ public class SimpleClient {
 
   private final Map<String, String> headers = new HashMap<>();
 
-  private CookieManager cookies;
+  private final CookieManager cookies;
+  private HttpURLConnection lastConnection;
 
   public SimpleClient(String host, int port) {
     this("http://" + host + ":" + port);
@@ -101,13 +103,14 @@ public class SimpleClient {
     URL url = new URL(rootUrl + path);
     HttpURLConnection con = (HttpURLConnection) url.openConnection();
     con.setRequestMethod(method);
+    this.lastConnection = con;
 
     addAdditionalHeaders(con);
     if (data != null) {
       con.setDoOutput(true);
 
       String body = data.toString();
-      con.getOutputStream().write(body.getBytes("UTF-8"));
+      con.getOutputStream().write(body.getBytes(StandardCharsets.UTF_8));
       con.getOutputStream().close();
     }
 
@@ -143,5 +146,12 @@ public class SimpleClient {
               "Basic " + java.util.Base64.getEncoder()
                                          .encodeToString((user + ":" + password)
                                                            .getBytes()));
+  }
+
+  /**
+   * Allows to access the last generated HTTP connection for test purposes.
+   */
+  public HttpURLConnection getLastConnection() {
+    return lastConnection;
   }
 }


### PR DESCRIPTION
This MR adds support for gzip content encoding. It is disabled by default except when using FlakResourceImpl to serve static data. 

To enable it, use the `@Compress` annotation where you need to add compression.